### PR TITLE
avoid name collision

### DIFF
--- a/gomockery.bzl
+++ b/gomockery.bzl
@@ -168,7 +168,7 @@ def _go_tool_run_shell_stdout(ctx, cmd, args, extra_inputs, outputs):
 # language: no regular expressions and no 'while' loops.
 def _interface_to_case(name, case):
     if case != "underscore":
-        return name
+        return name + "mock"
 
     transformed = ""
     idx = -1
@@ -200,9 +200,9 @@ def _interface_to_case(name, case):
                 state = 0
         else:
             fail("reached an unexpected parsing state")
-    
+
     if curr_word_start > 0:
         transformed += "_"
     transformed += name[curr_word_start:].lower()
 
-    return transformed
+    return transformed + "_mock"

--- a/gomockery.bzl
+++ b/gomockery.bzl
@@ -152,6 +152,12 @@ def _go_tool_run_shell_stdout(ctx, cmd, args, extra_inputs, outputs):
            export $(cut -d= -f1 go_env.txt) &&
            export PATH=$GOROOT/bin:$PWD/{godir}:$PATH &&
            export GOPATH={gopath} &&
+           export GOPACKAGESPRINTGOLISTERRORS=true &&
+           # TODO(zplin): Hack required to enable the default go/packages driver.
+           # This may or not may not be necessary with Go 1.12.
+           # For details, see https://github.com/golang/go/issues/30355.
+           mkdir -p bazel-out/_tmp/go-cache &&
+           export GOCACHE=$PWD/bazel-out/_tmp/go-cache &&
            {cmd} {args} &&
            sed -E -i.bak -e 's@"[^"]+{godep}/src/([^"]+)/"@"\\1"@g' {outfiles}
         """.format(

--- a/gomockery.bzl
+++ b/gomockery.bzl
@@ -17,7 +17,7 @@ def go_mockery(src, importpath, interfaces, visibility, **kwargs):
         src = src,
         interfaces = interfaces,
         case = kwargs.get("case", "underscore"),
-        outpkg = kwargs.get("outpkg", None),
+        outpkg = kwargs.get("outpkg", importpath.split("/")[-1]),
         mockery_tool = kwargs.get("mockery_tool", None),
         visibility = visibility,
     )


### PR DESCRIPTION
An interface called "Actions" may be defined in a file called `actions.go`. This PR will put the generated mock file under `mocks/actions.go` to avoid name collision with the original file even if the `gomockery` rule is in the same directory as the `go_library` rule.