### PR TITLE
In bazel-3.5.0 (or earlier) tools in run_files must be in tools attr

### DIFF
--- a/gomockery.bzl
+++ b/gomockery.bzl
@@ -136,7 +136,7 @@ def _go_tool_run_shell_stdout(ctx, cmd, args, extra_inputs, outputs):
 
     inputs = [cmd, go_ctx.go] + (
         ctx.attr.gopath_dep.files.to_list() +
-        go_ctx.sdk.headers + go_ctx.sdk.srcs + go_ctx.sdk.tools
+        go_ctx.sdk.headers + go_ctx.sdk.srcs
     ) + extra_inputs
 
     # We can use the go binary from the stdlib for most of the environment
@@ -146,6 +146,7 @@ def _go_tool_run_shell_stdout(ctx, cmd, args, extra_inputs, outputs):
     ctx.actions.run_shell(
         outputs = outputs,
         inputs = inputs,
+        tools = go_ctx.sdk.tools,
         command = """
            $PWD/{godir}/go env >go_env.txt &&
            source go_env.txt &&


### PR DESCRIPTION
Ran into this:

```
	File "/private/var/tmp/_bazel_allanc/df852130f994ac8d2b8c11d897c82c54/external/bazel_mockery/gomockery.bzl", line 146, column 26, in _go_tool_run_shell_stdout
		ctx.actions.run_shell(
Error in run_shell: Found tool(s) 'bazel-out/host/bin/external/com_github_vektra_mockery/cmd/mockery/darwin_amd64_stripped/mockery' in inputs. A tool is an input with executable=True set. All tools should be passed using the 'tools' argument instead of 'inputs' in order to make their runfiles available to the action. This safety check will not be performed once the action is modified to take a 'tools' argument. To temporarily disable this check, set --incompatible_no_support_tools_in_action_inputs=false.
```

This PR solved it.